### PR TITLE
Change default route to redirect to quiz page

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -23,7 +23,7 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Navigate to="/fragrances" replace />} />
+          <Route path="/" element={<Navigate to="/quiz" replace />} />
           <Route path="/fragrances" element={<Index />} />
           <Route path="/compare-intro" element={<CompareIntro />} />
           <Route path="/compare" element={<Compare />} />


### PR DESCRIPTION
## Purpose
The user requested to make the quiz page the first page that users see when visiting the application, improving the user experience by directing them to the quiz functionality immediately.

## Code changes
- Updated the default route (`/`) redirect from `/fragrances` to `/quiz` in the main App component
- This ensures users are automatically navigated to the quiz page when they visit the root URLTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a718929e379e493f8e875bb698ef9151/pulse-den)

👀 [Preview Link](https://a718929e379e493f8e875bb698ef9151-pulse-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a718929e379e493f8e875bb698ef9151</projectId>-->
<!--<branchName>pulse-den</branchName>-->