### PR TITLE
Update perfume pricing: 30ml to $34.99, 100ml to $69.99

### DIFF
--- a/client/components/PricingBanner.tsx
+++ b/client/components/PricingBanner.tsx
@@ -21,7 +21,7 @@ export function PricingBanner() {
                 30ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $29.99
+                $34.99
               </Badge>
             </div>
             <div className="flex items-center gap-1">
@@ -37,7 +37,7 @@ export function PricingBanner() {
                 100ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $74.99
+                $69.99
               </Badge>
             </div>
           </div>

--- a/client/components/StatsSection.tsx
+++ b/client/components/StatsSection.tsx
@@ -19,7 +19,7 @@ export function StatsSection() {
     {
       icon: Heart,
       label: "Starting From",
-      value: "$29.99",
+      value: "$34.99",
       description: "Unbeatable prices",
     },
     {

--- a/client/data/perfumes.ts
+++ b/client/data/perfumes.ts
@@ -57,7 +57,7 @@ export const perfumes: Perfume[] = [
     description:
       "A luminous and sophisticated fragrance inspired by the iconic Baccarat Rouge 540.",
     sizes: [
-      { size: "30ml", price: 29.99, originalPrice: 200 },
+      { size: "30ml", price: 34.99, originalPrice: 200 },
       { size: "50ml", price: 44.99, originalPrice: 295 },
       { size: "100ml", price: 69.99, originalPrice: 425 },
     ],

--- a/client/data/perfumes.ts
+++ b/client/data/perfumes.ts
@@ -25,7 +25,7 @@ export interface Perfume {
 
 // Standard Golden Aroma pricing
 export const standardSizes: PerfumeSize[] = [
-  { size: "30ml", price: 29.99 },
+  { size: "30ml", price: 34.99 },
   { size: "50ml", price: 44.99 },
   { size: "100ml", price: 69.99 },
 ];


### PR DESCRIPTION
## Purpose
Update perfume pricing structure based on user request to adjust costs for 30ml and 100ml sizes to improve pricing strategy.

## Code changes
- Updated 30ml perfume price from $29.99 to $34.99 across all components
- Updated 100ml perfume price from $74.99 to $69.99 in PricingBanner component
- Modified pricing in PricingBanner.tsx, StatsSection.tsx, and perfumes.ts data file
- Updated both standard pricing structure and individual perfume pricing configurationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a718929e379e493f8e875bb698ef9151/cosmos-den)

👀 [Preview Link](https://a718929e379e493f8e875bb698ef9151-cosmos-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a718929e379e493f8e875bb698ef9151</projectId>-->
<!--<branchName>cosmos-den</branchName>-->